### PR TITLE
Attempt to update gnusocial and its dependencies to v17

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -1,4 +1,4 @@
 #!/bin/bash -ex
 
 [ "$FAB_HTTP_PROXY" ] && PROXY="--proxy $FAB_HTTP_PROXY"
-curl -L -f $PROXY https://git.gnu.io/gnu/gnu-social/repository/archive.tar.gz -o /usr/local/src/gnusocial.tar.gz
+curl -L -f $PROXY https://notabug.org/diogo/gnu-social/archive/master.tar.gz -o /usr/local/src/gnusocial.tar.gz

--- a/conf.d/main
+++ b/conf.d/main
@@ -13,7 +13,7 @@ WEBROOT=/var/www/gnusocial
 # unpack tarball to webroot and set permissions
 tar -zxf /usr/local/src/gnusocial.tar.gz -C /var/www/
 rm -f /usr/local/src/gnusocial.tar.gz
-mv /var/www/gnu-social-* /var/www/gnusocial
+mv /var/www/gnu-social /var/www/gnusocial
 
 # fix missing dirs
 mkdir -p /var/www/gnusocial/{avatar,background,file}

--- a/overlay/usr/lib/inithooks/bin/gnusocial.py
+++ b/overlay/usr/lib/inithooks/bin/gnusocial.py
@@ -14,7 +14,7 @@ import inithooks_cache
 
 import crypt
 
-from dialog_wrapper import Dialog
+from libininthooks.dialog_wrapper import Dialog
 from mysqlconf import MySQL
 
 def usage(s=None):


### PR DESCRIPTION
Updating known issues with gnusocial.iso image build. Includes updating repository url location, tarball url link, and libinithooks. Removed code with error to rename /var/www/gnusocial/dir.